### PR TITLE
[ARGO-3635] Connection with the API and related key should be configurable via a file

### DIFF
--- a/src/api/Manager.js
+++ b/src/api/Manager.js
@@ -3,7 +3,7 @@ import {CONFIG} from '../config';
 const headers = {
     "Content-Type": "application/json",
     Accept: "application/json",
-    "x-api-key": ""
+    "x-api-key": process.env.REACT_APP_X_API_KEY
 };
 
 const getStatusServiceGroup = () => {


### PR DESCRIPTION
Get the X-API-KEY in the config.js from a .env varibable